### PR TITLE
こうすると動きました

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -18,5 +18,4 @@ require (
 	golang.org/x/oauth2 v0.20.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	golang.org/x/time v0.11.0 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -31,7 +31,5 @@ golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
 golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
-golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
-golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/main.go
+++ b/backend/main.go
@@ -19,7 +19,9 @@ func main() {
 	e := echo.New()
 
 
-	e.GET("/ubugoe/:userId", func(c echo.Context) error {
+	e.GET("api/ubugoe/:userId", func(c echo.Context) error { 
+		// フロントからは同じドメイン(https:ubugoechecker)の/apiにアクセスを飛ばす　(vite.config.tsで設定している)
+		// /api →　ならバックエンドという風にする。ので変更
 		userID := c.Param("userId")
 		//fmt.Println(channelID)
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 	traq "github.com/traPtitech/go-traq"
 )
 
@@ -19,13 +18,6 @@ func main() {
 
 	e := echo.New()
 
-	// domainUrl := "http://localhost:5173"
-	domainUrl := "https://frontubugoechecker.trap.show"
-	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-	AllowOrigins: []string{domainUrl}, // フロントエンドのURLを指定
-	AllowMethods: []string{"GET"}, // 許可するメソッド
-	AllowHeaders: []string{"Content-Type"}, // 許可するヘッダー
-}))
 
 	e.GET("/ubugoe/:userId", func(c echo.Context) error {
 		userID := c.Param("userId")

--- a/backend/main.go
+++ b/backend/main.go
@@ -19,7 +19,7 @@ func main() {
 	e := echo.New()
 
 
-	e.GET("api/ubugoe/:userId", func(c echo.Context) error { 
+	e.GET("/api/ubugoe/:userId", func(c echo.Context) error { 
 		// フロントからは同じドメイン(https:ubugoechecker)の/apiにアクセスを飛ばす　(vite.config.tsで設定している)
 		// /api →　ならバックエンドという風にする。ので変更
 		userID := c.Param("userId")

--- a/frontend/src/components/Checker.vue
+++ b/frontend/src/components/Checker.vue
@@ -5,7 +5,7 @@ const data = ref<string[]>()
 const query = ref<string>('')
 
 const getUbugoe = async (name: string) => {
-  const responce = await fetch(`https://ubugoechecker.trap.show/ubugoe/${name}`, {
+  const responce = await fetch(`/api/ubugoe/${name}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,5 +15,13 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
-
+  server: {
+    // 開発環境の場合は/apiのアクセスはlocalhost:8080に転送する。　この設定は本番だと無視され同じドメインのサーバーにアクセスする
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
バックエンド
![image](https://github.com/user-attachments/assets/8c4ee208-4d00-4ff4-9de9-2551531b755e)
フロントエンド
![image](https://github.com/user-attachments/assets/d288fec1-5c32-4154-8dec-eaf0d984b1be)

のようにドメインを共通にすることで動かすことが出来ました。(trapの認証をなくせば公開はできたのですが誰でもアクセスできてしまっていた)

ドメインを共通にすることでcorsの設定(外部のapiあぶなくない？)がいらなくなります。
またドメインを共通にしてバックエンドを /api 以下　に対応させたのでそれに伴ってエンドポイントも少し変更しています。
